### PR TITLE
Move "apt-get clean" to the same layer as "apt-get install"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,8 @@ RUN apt-get update && apt-get -y install \
     php5-fpm \
     php5-pgsql \
     php5-mysql \
-    php5-sqlite
-
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    php5-sqlite \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN curl -sS https://getcomposer.org/installer | php -- \
              --install-dir=/usr/local/bin \


### PR DESCRIPTION
This prevent from commiting what the next command removes, saving about 20mo in image size.
